### PR TITLE
[Merged by Bors] - fix(tui): replace tab with whitespace in value

### DIFF
--- a/systeroid-tui/src/ui.rs
+++ b/systeroid-tui/src/ui.rs
@@ -68,15 +68,16 @@ fn render_parameter_list<B: Backend>(
         .unwrap_or(1);
     let minimize_rows = rect.width < max_width + 10;
     let rows = app.parameter_list.items.iter().map(|item| {
+        let value = item.value.replace('\t', " ");
         Row::new(if minimize_rows {
             vec![Cell::from(Span::styled(
-                format!("{} = {}", item.name, item.value),
+                format!("{} = {}", item.name, value),
                 colors.get_fg_style(),
             ))]
         } else {
             vec![
                 Cell::from(Span::styled(item.name.clone(), colors.get_fg_style())),
-                Cell::from(Span::styled(item.value.clone(), colors.get_fg_style())),
+                Cell::from(Span::styled(value, colors.get_fg_style())),
             ]
         })
         .height(1)


### PR DESCRIPTION
## Description

Replace `\t` with whitespace in values, to separated vector values.

## Motivation and Context

Vector values (eg, net.ipv4_mem) are separated by `\t`, but tui could not display `\t` correctly.

Fix https://github.com/orhun/systeroid/issues/14.


## How Has This Been Tested?

Visually checked

## Screenshots / Logs (if applicable)

Before:

![sc-20220419-122855](https://user-images.githubusercontent.com/24709398/163920309-756a9334-252f-4901-9231-a6183f91061d.png)

After:

![sc-20220419-122941](https://user-images.githubusercontent.com/24709398/163920378-611f6597-0ae8-40e1-95c8-1c8039473254.png)


## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (no code change)
- [ ] Refactor (refactoring production code)
- [ ] Other <!--- (provide information) -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly.
- [X] I have formatted the code with [rustfmt](https://github.com/rust-lang/rustfmt).
- [X] I checked the lints with [clippy](https://github.com/rust-lang/rust-clippy).
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
