### PR TITLE
chore(deps): switch to `ratatui`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -590,6 +590,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "ratatui"
+version = "0.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcc0d032bccba900ee32151ec0265667535c230169f5a011154cdcd984e16829"
+dependencies = [
+ "bitflags",
+ "cassowary",
+ "termion",
+ "unicode-segmentation",
+ "unicode-width",
+]
+
+[[package]]
 name = "rayon"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -826,23 +839,11 @@ dependencies = [
  "colorsys",
  "copypasta-ext",
  "getopts",
+ "ratatui",
  "systeroid-core",
- "termion 2.0.1",
+ "termion",
  "thiserror",
- "tui",
  "unicode-width",
-]
-
-[[package]]
-name = "termion"
-version = "1.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "077185e2eac69c3f8379a4298e1e07cd36beb962290d4a51199acf0fdc10607e"
-dependencies = [
- "libc",
- "numtoa",
- "redox_syscall",
- "redox_termios",
 ]
 
 [[package]]
@@ -884,19 +885,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5516c27b78311c50bf42c071425c560ac799b11c30b31f87e3081965fe5e0180"
 dependencies = [
  "once_cell",
-]
-
-[[package]]
-name = "tui"
-version = "0.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccdd26cbd674007e649a272da4475fb666d3aa0ad0531da7136db6fab0e5bad1"
-dependencies = [
- "bitflags",
- "cassowary",
- "termion 1.5.6",
- "unicode-segmentation",
- "unicode-width",
 ]
 
 [[package]]

--- a/systeroid-tui/Cargo.toml
+++ b/systeroid-tui/Cargo.toml
@@ -30,7 +30,8 @@ version = "0.3.1" # managed by release.sh
 path = "../systeroid-core"
 
 [dependencies.tui]
-version = "0.19.0"
+package = "ratatui"
+version = "0.20.1"
 default-features = false
 features = ["termion"]
 


### PR DESCRIPTION
## Description
Updated Cargo.{toml,lock} according to the [instructions](https://github.com/tui-rs-revival/ratatui/#install) to use `ratatui` instead of `tui`.

## Motivation and Context
Resolves #77 

## How Has This Been Tested?
- Run `docker build -t systeroid .` to build the image
- Run `docker run -it systeroid` to test the application (modified the entrypoint to use `--tui`)
- Surface test of the UI

## Screenshots / Logs (if applicable)

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (no code change)
- [ ] Refactor (refactoring production code)
- [x] Other — dependency replacement

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly.
- [x] I have formatted the code with [rustfmt](https://github.com/rust-lang/rustfmt).
- [x] I checked the lints with [clippy](https://github.com/rust-lang/rust-clippy).
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
