### PR TITLE
refactor(tui): improve the termion panic hook

### DIFF
--- a/systeroid-tui/src/main.rs
+++ b/systeroid-tui/src/main.rs
@@ -11,16 +11,13 @@ use termion::screen::IntoAlternateScreen;
 
 fn main() -> Result<()> {
     if let Some(args) = Args::parse(env::args().collect()) {
-        /* create a raw terminal, and immediately exit raw mode to set correct prev_ios value*/
         let raw_output = io::stderr().into_raw_mode()?;
         raw_output.suspend_raw_mode()?;
 
         let panic_hook = panic::take_hook();
-
-        panic::set_hook(Box::new (move |panic| {
+        panic::set_hook(Box::new(move |panic| {
             let panic_cleanup = || -> Result<()> {
                 let mut output = io::stderr();
-    
                 write!(
                     output,
                     "{}{}{}",
@@ -32,7 +29,7 @@ fn main() -> Result<()> {
                 output.flush()?;
                 Ok(())
             };
-    
+
             panic_cleanup().expect("Failed to cleanup after panic");
             panic_hook(panic);
         }));

--- a/systeroid-tui/src/main.rs
+++ b/systeroid-tui/src/main.rs
@@ -12,14 +12,14 @@ use termion::screen::IntoAlternateScreen;
 fn main() -> Result<()> {
     if let Some(args) = Args::parse(env::args().collect()) {
         /* create a raw terminal, and immediately exit raw mode to set correct prev_ios value*/
-        let raw_output = io::stdout().into_raw_mode()?;
+        let raw_output = io::stderr().into_raw_mode()?;
         raw_output.suspend_raw_mode()?;
 
         let panic_hook = panic::take_hook();
 
         panic::set_hook(Box::new (move |panic| {
             let panic_cleanup = || -> Result<()> {
-                let mut output = io::stdout();
+                let mut output = io::stderr();
     
                 write!(
                     output,


### PR DESCRIPTION
## Description
Termion error handler does not work correctly with current version, so we decided that to rewrite it within https://github.com/orhun/kmon/pull/141 and implemented the same for systeroid-tui.

## Motivation and Context
https://github.com/orhun/systeroid/issues/168

## How Has This Been Tested?
I put panic!() to the lib.rs to generate panic and test if terminal will be messed up or not.

## Screenshots / Logs (if applicable)
![image](https://github.com/orhun/systeroid/assets/46849939/5d0d0d83-21be-48b6-bab4-b8d28fcf1f15)

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (no code change)
- [x] Refactor (refactoring production code)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly.
- [ ] I have formatted the code with [rustfmt](https://github.com/rust-lang/rustfmt).
- [ ] I checked the lints with [clippy](https://github.com/rust-lang/rust-clippy).
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
