### PR TITLE
feat(tui)!: Use transparent background by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -572,6 +572,7 @@ Press <kbd>c</kbd> to show the options menu for copying the name, value, or docu
 #### Changing the colors
 
 Use `--bg-color` and `--fg-color` arguments to customize the colors of the terminal user interface.
+A transparent background is used by default.
 
 ```sh
 # use a color name for setting the foreground color
@@ -580,7 +581,7 @@ systeroid-tui --fg-color blue
 # use hexadecimal values for setting foreground/background colors
 systeroid-tui --bg-color ffff99 --fg-color 003366
 
-# use transparent background
+# use transparent background (default as of 0.5.0)
 systeroid-tui --bg-color reset
 ```
 

--- a/README.md
+++ b/README.md
@@ -581,7 +581,7 @@ systeroid-tui --fg-color blue
 # use hexadecimal values for setting foreground/background colors
 systeroid-tui --bg-color ffff99 --fg-color 003366
 
-# use transparent background (default as of 0.5.0)
+# use transparent background (default as of 0.4.6)
 systeroid-tui --bg-color reset
 ```
 

--- a/systeroid-tui/src/args.rs
+++ b/systeroid-tui/src/args.rs
@@ -70,7 +70,7 @@ impl Args {
         opts.optopt(
             "",
             "bg-color",
-            "set the background color [default: black]",
+            "set the background color [default: reset (transparent)]",
             "<color>",
         );
         opts.optopt(
@@ -134,7 +134,7 @@ impl Args {
                     .unwrap_or_else(|| String::from("white")),
                 bg_color: matches
                     .opt_str("bg-color")
-                    .unwrap_or_else(|| String::from("black")),
+                    .unwrap_or_else(|| String::from("reset")),
                 no_docs: matches.opt_present("n"),
                 display_deprecated: matches.opt_present("deprecated"),
                 config: matches


### PR DESCRIPTION
## Description
Right now the default background color of systeroid-tui is black, which
is not great when it comes to different color schemes.

This change replaces `black` with `reset` as the default.
(reset means transparent in this context)

BREAKING CHANGE: Use transparent background by default

----

I changed the README to reference the new release. If the next one is not `0.5.0`, I'll have to change the version number accordinglt in another commit.


## Motivation and Context
closes #154 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

cargo test
manual tests

## Screenshots / Logs (if applicable)

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation (no code change)
- [ ] Refactor (refactoring production code)
- [ ] Other <!--- (provide information) -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [x] I have formatted the code with [rustfmt](https://github.com/rust-lang/rustfmt).
- [x] I checked the lints with [clippy](https://github.com/rust-lang/rust-clippy).
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
